### PR TITLE
Dict compiler issue

### DIFF
--- a/DictTest.roc
+++ b/DictTest.roc
@@ -1,0 +1,12 @@
+app "dict-test"
+    packages { pf: "https://github.com/roc-lang/basic-cli/releases/download/0.1.1/zAoiC9xtQPHywYk350_b7ust04BmWLW00sjb9ZPtSQk.tar.br" }
+    imports [pf.Process, pf.Stdout, pf.Task]
+    provides [main] to pf
+
+main =
+    myDict : Dict Nat Str
+    myDict =
+        Dict.single 1 "One"
+
+    _ <- Task.await (Stdout.line "ok")
+    Process.exit 0

--- a/Util.roc
+++ b/Util.roc
@@ -1,5 +1,5 @@
 interface Util
-    exposes [groupsOf, updateAt]
+    exposes [groupsOf, updateAt, updateIfFound]
     imports []
 
 groupsOf : List a, Nat -> List (List a)
@@ -31,3 +31,13 @@ updateAt = \list, index, fn ->
         List.concat before (List.prepend (List.dropFirst others) (fn element))
 
     Result.withDefault result list
+
+
+updateIfFound : (a -> a) -> ([Present a, Missing] -> [Present a, Missing])
+updateIfFound = \f ->
+    \element ->
+        when element is
+            Present a ->
+                Present (f a)
+            Missing ->
+                Missing


### PR DESCRIPTION
Here's the compiler error when trying to run `roc build Day5.roc`:

```
An internal compiler expectation was broken.
This is definitely a compiler bug.
Please file an issue here: https://github.com/roc-lang/roc/issues/new/choose
thread '<unnamed>' panicked at 'ambient functions don't unify', /home/big-ci-user/actions-runner/_work/roc/roc/crates/compiler/unify/src/unify.rs:247:18
```

with full stacktrace:
```
An internal compiler expectation was broken.
This is definitely a compiler bug.
Please file an issue here: https://github.com/roc-lang/roc/issues/new/choose
thread '<unnamed>' panicked at 'ambient functions don't unify', /home/big-ci-user/actions-runner/_work/roc/roc/crates/compiler/unify/src/unify.rs:247:18
stack backtrace:
   0:     0x56210733af34 - std::backtrace_rs::backtrace::libunwind::trace::h9135f25bc195152c
                               at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/std/src/../../backtrace/src/backtrace/libunwind.rs:93:5
   1:     0x56210733af34 - std::backtrace_rs::backtrace::trace_unsynchronized::h015ee85be510df51
                               at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/std/src/../../backtrace/src/backtrace/mod.rs:66:5
   2:     0x56210733af34 - std::sys_common::backtrace::_print_fmt::h5fad03caa9652a2c
                               at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/std/src/sys_common/backtrace.rs:66:5
   3:     0x56210733af34 - <std::sys_common::backtrace::_print::DisplayBacktrace as core::fmt::Display>::fmt::h2b42ca28d244e5c7
                               at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/std/src/sys_common/backtrace.rs:45:22
   4:     0x5621065a608c - core::fmt::write::h401e827d053130ed
                               at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/core/src/fmt/mod.rs:1198:17
   5:     0x562107334065 - std::io::Write::write_fmt::hffec93268f5cde32
                               at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/std/src/io/mod.rs:1672:15
   6:     0x56210733cb5a - std::sys_common::backtrace::_print::h180c4c706ee1d3fb
                               at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/std/src/sys_common/backtrace.rs:48:5
   7:     0x56210733cb5a - std::sys_common::backtrace::print::hd0c35d18765761c9
                               at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/std/src/sys_common/backtrace.rs:35:9
   8:     0x56210733cb5a - std::panicking::default_hook::{{closure}}::h1f023310983bc730
                               at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/std/src/panicking.rs:295:22
   9:     0x56210733c84a - std::panicking::default_hook::h188fec3334afd5be
                               at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/std/src/panicking.rs:314:9
  10:     0x56210733d188 - std::panicking::rust_panic_with_hook::hf26e9d4f97b40096
                               at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/std/src/panicking.rs:698:17
  11:     0x56210733d084 - std::panicking::begin_panic_handler::{{closure}}::hfab912107608087a
                               at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/std/src/panicking.rs:588:13
  12:     0x56210733b4b4 - std::sys_common::backtrace::__rust_end_short_backtrace::h434b685ce8d9965b
                               at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/std/src/sys_common/backtrace.rs:138:18
  13:     0x56210733cded - rust_begin_unwind
                               at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/std/src/panicking.rs:584:5
  14:     0x5621063fab83 - core::panicking::panic_fmt::ha6dc7f2ab2479463
                               at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/core/src/panicking.rs:142:14
  15:     0x562106cf5d98 - core::panicking::panic_display::h6543229adbc66bfb
  16:     0x562106cfdf3b - roc_solve::specialize::compact_lambda_sets_of_vars::hf39ce63a4aee8364
  17:     0x562106d310a2 - roc_late_solve::unify::h7e13ea8df944bdd3
  18:     0x562106ea3334 - roc_mono::ir::Env::unify::h5b417b90ecf46d14
  19:     0x562106eb1368 - roc_mono::ir::specialize_variable::h54a6126c7d259492
  20:     0x562106edc64f - roc_mono::ir::call_by_name::hb8f74caaa13671c6
  21:     0x562106eb94c0 - roc_mono::ir::with_hole::h7bfa4166c1dcc373
  22:     0x562106ecd10e - roc_mono::ir::from_can::h1d0bda6f5ff288e8
  23:     0x562106ed072b - roc_mono::ir::from_can_when::h2f267720cfaf88c1
  24:     0x562106ecc543 - roc_mono::ir::from_can::h1d0bda6f5ff288e8
  25:     0x562106eaa13b - roc_mono::ir::from_can_let::he702cfdd0d51b42b
  26:     0x562106eccf99 - roc_mono::ir::from_can::h1d0bda6f5ff288e8
  27:     0x562106eb2d34 - roc_mono::ir::specialize_variable::h54a6126c7d259492
  28:     0x562106eafb01 - roc_mono::ir::specialize_external_help::h0827ca3094bf870d
  29:     0x562106eaf15d - roc_mono::ir::specialize_all::hc28d217acb38378f
  30:     0x562106e25389 - roc_load_internal::file::run_task::h15f85d38f69e0f83
  31:     0x562106db1fe1 - core::ops::function::FnOnce::call_once{{vtable.shim}}::hfd874eb059a06654
  32:     0x562106da9bae - std::sys_common::backtrace::__rust_begin_short_backtrace::hf6dbee4b912148d0
  33:     0x562106db128d - core::ops::function::FnOnce::call_once{{vtable.shim}}::h4c3cdf2389722774
  34:     0x562107342655 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h56d5fc072706762b
                               at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/alloc/src/boxed.rs:1935:9
  35:     0x562107342655 - <alloc::boxed::Box<F,A> as core::ops::function::FnOnce<Args>>::call_once::h41deef8e33b824bb
                               at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/alloc/src/boxed.rs:1935:9
  36:     0x562107342655 - std::sys::unix::thread::Thread::new::thread_start::ha6436304a1170bba
                               at /rustc/a55dd71d5fb0ec5a6a3a9e8c27b2127ba491ce52/library/std/src/sys/unix/thread.rs:108:17
  37:     0x7ff353c99ea7 - start_thread
  38:     0x7ff353840a2f - clone
  39:                0x0 - <unknown>